### PR TITLE
Adding `SkMemInfo` and targetted requests

### DIFF
--- a/protocols.go
+++ b/protocols.go
@@ -155,6 +155,7 @@ type NetOption struct {
 	Family   uint8
 	Protocol uint8
 	State    uint32
+	ID       SockID
 }
 
 // NetDump returns network socket information.
@@ -163,6 +164,7 @@ func (d *Diag) NetDump(opt *NetOption) ([]NetObject, error) {
 		Family:   opt.Family,
 		Protocol: opt.Protocol,
 		States:   opt.State,
+		ID:       opt.ID,
 	}
 
 	respMsgs, err := d.dumpQuery(header)

--- a/protocols.go
+++ b/protocols.go
@@ -154,6 +154,7 @@ type SctpInfo struct {
 type NetOption struct {
 	Family   uint8
 	Protocol uint8
+	Ext      uint8
 	State    uint32
 	ID       SockID
 }
@@ -163,6 +164,7 @@ func (d *Diag) NetDump(opt *NetOption) ([]NetObject, error) {
 	header := InetDiagReqV2{
 		Family:   opt.Family,
 		Protocol: opt.Protocol,
+		Ext:      opt.Ext,
 		States:   opt.State,
 		ID:       opt.ID,
 	}

--- a/types.go
+++ b/types.go
@@ -143,6 +143,7 @@ type NetAttribute struct {
 	TOS       *uint8
 	TClass    *uint8
 	Shutdown  *uint8
+	SkMemInfo *SkMemInfo
 	DCTCPInfo *DCTCPInfo
 	Protocol  *uint8
 	SKV6Only  *uint8
@@ -194,6 +195,28 @@ type MemInfo struct {
 	WMem uint32
 	FMem uint32
 	TMem uint32
+}
+
+// Based on sock_diag(7)
+type SkMemInfo struct {
+	// The amount of data in receive queue.
+	RMemAlloc uint32
+	// The receive socket buffer as set by SO_RCVBUF.
+	RcvBuff uint32
+	// The amount of data in send queue.
+	WMemAlloc uint32
+	// The send socket buffer as set by SO_SNDBUF.
+	SndBuff uint32
+	// The amount of memory scheduled for future use (TCP only).
+	FwdAlloc uint32
+	// The amount of data queued by TCP, but not yet sent.
+	WMemQueued uint32
+	// The amount of memory allocated for the socket's service needs (e.g., socket filter).
+	OptMem uint32
+	// The amount of packets in the backlog (not yet processed).
+	Backlog uint32
+	// Check https://manpages.debian.org/stretch/manpages/sock_diag.7.en.html
+	Drops uint32
 }
 
 // Based on tcp_bbr_info


### PR DESCRIPTION
Hi @florianl! First of all, thanks a ton for your superb work on `go-diag`: it's been a lifesaver!

I forked the project to add a couple missing pieces I needed for `scitags/flowd-go` and I though I'd let you know in case you'd be interested in them. The basically boil down to:

1. Adding support for so called "Socket Memory Information" (i.e. `SkMemInfo`) as set forth in [`sock_diag(7)`][sock-diag].
1. Extending the `NetOption` struct to allow for finer requests, including:
    1. Specifying a particular socket to query through a `SockID` struct as explained in [`sock_diag(7)`][sock-diag].
    2. Specifying requested information through a `uint32` as explained in [`sock_diag(7)`][sock-diag].

I changed all references to `github.com/florianl/go-diag` to `github.com/scitags/go-diag` so that I could import the module in my project. If you believe this PR is desirable I'll be more than happy to revert these changes in a fresh fork: I just wanted to know whether you were interested beforehand...

Anyway, thanks again for your work. Feel free to close the PR if you're not interested in the changes.

Have a great day!

<!-- REFs -->
[sock-diag]: https://www.man7.org/linux/man-pages/man7/sock_diag.7.html